### PR TITLE
Added functionality to attach license badges to the generated `README.md` files 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
-// TODO: Include packages needed for this application
 const fs = require("fs");
 const inquirer = require("inquirer");
 
-// TODO: Create an array of questions for user input
 const questions = [
     {
         type: "input",
@@ -54,14 +52,15 @@ const questions = [
     }
 ];
 
-// TODO: Create a function to write README file
 function writeToFile(fileName, data) {
     fs.writeFile(fileName, data, (err) => 
     err ? console.error(err) : console.log("Your professional README.md file has been exported!"))
 }
 
 function constructREADME(data) {
-    const generatedREADME = `# ${data.projectTitle}
+    const badgeLink = badgeRequest(data);
+    const generatedREADME = `${badgeLink}
+# ${data.projectTitle}
 
 ## Description
 
@@ -134,38 +133,35 @@ function badgeRequest(data) {
             badgeLink = "[![License](https://img.shields.io/badge/License-EPL_2.0-2C2255?style=for-the-badge)](https://opensource.org/license/epl-2-0/)";
             break;
         case "GNU Affero General Public License v3.0":
-            badgeLink = "[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)";
+            badgeLink = "[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)";
             break;
         case "GNU General Public License v2.0":
             badgeLink = "[![License: GPL v2](https://img.shields.io/badge/License-GPL_v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)";
             break;
         case "GNU Lesser General Public License v2.1":
-            badgeLink = "https://img.shields.io/badge/License-LGPL_v2.1-blue.svg";
+            badgeLink = "[![License](https://img.shields.io/badge/License-LGPL_v2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)";
             break;
         case "Mozilla Public License 2.0":
             badgeLink = "[![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)";
             break;
         case "The Unlicense":
-            badgeLink = "[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)";
+            badgeLink = "[![License: Unlicense](https://img.shields.io/badge/License-Unlicense-blue.svg)](http://unlicense.org/)";
             break;
         default:
             badgeLink = ""
             break;
     }
-    return badgeLink
+    return badgeLink;
 }
 
-// TODO: Create a function to initialize app
 function init() {
     inquirer
     .prompt(questions)
     .then((response) => {
         const generatedREADME = constructREADME(response);
-        console.log(generatedREADME);
         writeToFile('professional-README.md', generatedREADME);
     })
 
 }
 
-// Function call to initialize app
 init();

--- a/index.js
+++ b/index.js
@@ -102,6 +102,59 @@ If you have any additional questions, please feel free to [contact me](mailto:${
     return generatedREADME
 }
 
+function badgeRequest(data) {
+    const badgeSelection = data.license;
+    let badgeLink = ""
+    switch (badgeSelection) {
+        case "None":
+            badgeLink = "";
+            break;
+        case "Apache License 2.0": 
+            badgeLink = "[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)";
+            break;
+        case "GNU General Public License v3.0":
+            badgeLink = "[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)";
+            break;
+        case "MIT License":
+            badgeLink = "[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)";
+            break;
+        case 'BSD 2-Clause "Simplified"':
+            badgeLink = "[![License](https://img.shields.io/badge/License-BSD_2--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)";
+            break;
+        case 'BSD 3-Clause "New" or "Revised" License':
+            badgeLink = "[![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)";
+            break;
+        case  "Boost Software License 1.0":
+            badgeLink = "[![License](https://img.shields.io/badge/License-Boost_1.0-lightblue.svg)](https://www.boost.org/LICENSE_1_0.txt)";
+            break;
+        case "Creative Commons Zero v1.0 Universal":
+            badgeLink = "[![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](http://creativecommons.org/publicdomain/zero/1.0/)";
+            break;
+        case "Eclipse Public License 2.0": 
+            badgeLink = "[![License](https://img.shields.io/badge/License-EPL_2.0-2C2255?style=for-the-badge)](https://opensource.org/license/epl-2-0/)";
+            break;
+        case "GNU Affero General Public License v3.0":
+            badgeLink = "[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)";
+            break;
+        case "GNU General Public License v2.0":
+            badgeLink = "[![License: GPL v2](https://img.shields.io/badge/License-GPL_v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)";
+            break;
+        case "GNU Lesser General Public License v2.1":
+            badgeLink = "https://img.shields.io/badge/License-LGPL_v2.1-blue.svg";
+            break;
+        case "Mozilla Public License 2.0":
+            badgeLink = "[![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)";
+            break;
+        case "The Unlicense":
+            badgeLink = "[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)";
+            break;
+        default:
+            badgeLink = ""
+            break;
+    }
+    return badgeLink
+}
+
 // TODO: Create a function to initialize app
 function init() {
     inquirer


### PR DESCRIPTION
- Defined a function, `badgeRequest()`, that uses the user's selected license and utilizes a switch statement to return a link to a license badge hosted on `Shields.io` as well as a link to license documentation.

- Incorporated this functionality into the `constructREADME()` function and added the badge and its links to the README template literal, placing it at the top of the page. 


NOTE: The function name `generateREADME()` in commit 2acb744 is incorrect. The function's name is `constructREADME()`.

